### PR TITLE
Fix dns_local_name in scaleway_vpc_public_gateway_dhcp

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -71,7 +71,7 @@ resource "scaleway_vpc_public_gateway_dhcp" "main" {
   dns_servers_override = concat([
     var.gateway_dhcp_address
   ], var.gateway_dhcp_dns_server_servers_override)
-  dns_local_name = scaleway_vpc_private_network.main[count.index].name
+  dns_local_name = replace(scaleway_vpc_private_network.main[count.index].name, "_", "-")
   valid_lifetime = var.gateway_dhcp_valid_lifetime
   renew_timer    = var.gateway_dhcp_renew_timer
   rebind_timer   = var.gateway_dhcp_rebind_timer


### PR DESCRIPTION
## Description

If you have an `_`in the name of the Private Network, this module return this error at the apply:

```
╷
│ Error: scaleway-sdk-go: invalid argument(s): dns_local_name is wrongly formatted, regex: {}
│ 
│   with module.scw_vpc.scaleway_vpc_public_gateway_dhcp.main[0],
│   on .terraform/modules/scw_vpc/main.tf line 62, in resource "scaleway_vpc_public_gateway_dhcp" "main":
│   62: resource "scaleway_vpc_public_gateway_dhcp" "main" {
│ 
╵
```

It is because the pn name is use to set the `dns_local_name` of the `vpc_public_gateway_dhcp` resource and this field does not allow the `_` char.
Source: https://registry.terraform.io/providers/scaleway/scaleway/latest/docs/resources/vpc_public_gateway_dhcp#dns_local_name

## How to reproduce?

```hcl
module "scw_vpc" {
  source  = "scaleway/vpc-module/scaleway"
  version = ">= 1.0.0"
  name = "vpc"
  public_gateway_name  = "default_vpc"
  private_network_name = "default_pn"
  zones                = ["fr-par-2"]
  public_gateway_bastion_enabled = true
}
```