### PR TITLE
FEAT: Private Network Subnet

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,7 @@ No modules.
 | <a name="input_instances"></a> [instances](#input\_instances) | A map of interface and/or instance mac addresses containing their properties | `any` | `{}` | no |
 | <a name="input_list_reservations"></a> [list\_reservations](#input\_list\_reservations) | Defines whether to list reservations addresses) | `bool` | `false` | no |
 | <a name="input_name"></a> [name](#input\_name) | Name to be used on all the resources as identifier | `string` | `""` | no |
+| <a name="input_private_network_ipv4_subnet"></a> [private\_network\_ipv4\_subnet](#input\_private\_network\_ipv4\_subnet) | IPv4 subnet to be used on private network resource | `string` | `"192.168.0.0/24"` | no |
 | <a name="input_private_network_name"></a> [private\_network\_name](#input\_private\_network\_name) | Name to be used on private network resource as identifier | `string` | `""` | no |
 | <a name="input_public_gateway_bastion_enabled"></a> [public\_gateway\_bastion\_enabled](#input\_public\_gateway\_bastion\_enabled) | Defines whether SSH bastion is enabled on the gateway | `bool` | `true` | no |
 | <a name="input_public_gateway_name"></a> [public\_gateway\_name](#input\_public\_gateway\_name) | Name to be used on gateway resource as identifier | `string` | `""` | no |

--- a/main.tf
+++ b/main.tf
@@ -56,6 +56,10 @@ resource "scaleway_vpc_private_network" "main" {
     var.vpc_tags,
   )
   zone = length(regexall("^[a-z]{2}-", element(var.zones, count.index))) > 0 ? element(var.zones, count.index) : null
+
+  ipv4_subnet {
+    subnet = var.private_network_ipv4_subnet
+  }
 }
 
 ### DHCP Space of VPC Public Gateway

--- a/variables.tf
+++ b/variables.tf
@@ -98,6 +98,12 @@ variable "private_network_name" {
   description = "Name to be used on private network resource as identifier"
 }
 
+variable "private_network_ipv4_subnet" {
+  type        = string
+  default     = "192.168.0.0/24"
+  description = "IPv4 subnet to be used on private network resource"
+}
+
 ################################################################################
 # DHCP
 ################################################################################


### PR DESCRIPTION
Add the ability to set the subnet of a private network.

To create a Kapsule with a Private Network you need a /22 network ("Private Network subnets are too short").
Source : https://www.scaleway.com/en/docs/containers/kubernetes/reference-content/secure-cluster-with-private-network/#which-ip-ranges-are-used-for-the-private-network-of-my-cluster